### PR TITLE
Generate scaffold to spring 1 and 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+spring-boot-generate/target/
+spring-scaffold-cli/target/

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ And install the Spring Scaffold plugin
     $ spring scaffold -n "User" -p "name:String email:String"
     $ spring db:create -p "mysql"
     $ mvn spring-boot:run
-   
+
+Default is spring 1.x, edit scaffold.info to change to 2.x before run *spring scaffold*.
+
 # Structure
 
     __com

--- a/spring-boot-generate/src/main/java/br/com/generate/ReadScaffoldInfo.java
+++ b/spring-boot-generate/src/main/java/br/com/generate/ReadScaffoldInfo.java
@@ -102,15 +102,21 @@ public abstract class ReadScaffoldInfo {
 		return null;
 	}
 	
-	public String getSpringVersion() throws IOException {
-		BufferedReader readArq = new BufferedReader(getArq());
-		String row = readArq.readLine();
-		while (row != null) {
-			row = readArq.readLine();
-			String [] values = row.split(":");
-			if (values[0].equals("springVersion")) {
-				return values[1];
-			}
+	public String getSpringVersion() {
+		try {
+			BufferedReader readArq = new BufferedReader(getArq());
+			String row = readArq.readLine();
+		    while (row != null) {
+			    row = readArq.readLine();
+			    String [] values = row.split(":");
+			    if (values[0].equals("springVersion")) {
+				    return values[1];
+			    }
+            }
+        } catch (FileNotFoundException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
 		}
 		return null;
 	}

--- a/spring-boot-generate/src/main/java/br/com/generate/ReadScaffoldInfo.java
+++ b/spring-boot-generate/src/main/java/br/com/generate/ReadScaffoldInfo.java
@@ -102,4 +102,17 @@ public abstract class ReadScaffoldInfo {
 		return null;
 	}
 	
+	public String getSpringVersion() throws IOException {
+		BufferedReader readArq = new BufferedReader(getArq());
+		String row = readArq.readLine();
+		while (row != null) {
+			row = readArq.readLine();
+			String [] values = row.split(":");
+			if (values[0].equals("springVersion")) {
+				return values[1];
+			}
+		}
+		return null;
+	}
+	
 }

--- a/spring-boot-generate/src/main/java/br/com/generate/java/command/service/ServiceGenerator.java
+++ b/spring-boot-generate/src/main/java/br/com/generate/java/command/service/ServiceGenerator.java
@@ -15,15 +15,13 @@ public class ServiceGenerator extends ReadTemplateFile {
 	@Override
 	protected String operationGenerate(String javaStrings, String nameClass, String parameters) {
 		if ( getSpringVersion().equals("2.x") ) {
-			javaStrings.replace(".findOne(id)", ".findById(id).get()");
+			javaStrings = javaStrings.replace(".findOne(id)", ".findById(id).get()");
 		}
-
 		return javaStrings.replace("${package}", getPackage() + ".service")
 				.replace("${package_model}", getPackage() + ".model")
 				.replace("${package_repository}", getPackage() + ".repository")
 				.replace("${className}", nameClass)
 				.replace("${paramClassName}", nameClass.toLowerCase());
-
 	}
 
 	public static void main(String[] args) throws IOException {

--- a/spring-boot-generate/src/main/java/br/com/generate/java/command/service/ServiceGenerator.java
+++ b/spring-boot-generate/src/main/java/br/com/generate/java/command/service/ServiceGenerator.java
@@ -14,7 +14,7 @@ public class ServiceGenerator extends ReadTemplateFile {
 
 	@Override
 	protected String operationGenerate(String javaStrings, String nameClass, String parameters) {
-		if ( getSpringVersion() == "2.x" ) {
+		if ( getSpringVersion().equals("2.x") ) {
 			javaStrings.replace(".findOne(id)", ".findById(id).get()");
 		}
 

--- a/spring-boot-generate/src/main/java/br/com/generate/java/command/service/ServiceGenerator.java
+++ b/spring-boot-generate/src/main/java/br/com/generate/java/command/service/ServiceGenerator.java
@@ -4,24 +4,20 @@ import java.io.IOException;
 
 import br.com.generate.Layers;
 import br.com.generate.ReadTemplateFile;
-import br.com.generate.ReadScaffoldInfo;
 
 public class ServiceGenerator extends ReadTemplateFile {
 	
-	String springVersion = getSpringVersion();
-
 	@Override
 	public String getLayer() {
 		return Layers.SERVICE;
 	}
-	
-	public function 
 
 	@Override
 	protected String operationGenerate(String javaStrings, String nameClass, String parameters) {
-		if (this.springVersion == '2.x') {
-			javaStrings.replace('.findOne(id)', '.findById(id).get()');
+		if ( getSpringVersion() == "2.x" ) {
+			javaStrings.replace(".findOne(id)", ".findById(id).get()");
 		}
+
 		return javaStrings.replace("${package}", getPackage() + ".service")
 				.replace("${package_model}", getPackage() + ".model")
 				.replace("${package_repository}", getPackage() + ".repository")

--- a/spring-boot-generate/src/main/java/br/com/generate/java/command/service/ServiceGenerator.java
+++ b/spring-boot-generate/src/main/java/br/com/generate/java/command/service/ServiceGenerator.java
@@ -4,16 +4,24 @@ import java.io.IOException;
 
 import br.com.generate.Layers;
 import br.com.generate.ReadTemplateFile;
+import br.com.generate.ReadScaffoldInfo;
 
 public class ServiceGenerator extends ReadTemplateFile {
+	
+	String springVersion = getSpringVersion();
 
 	@Override
 	public String getLayer() {
 		return Layers.SERVICE;
 	}
+	
+	public function 
 
 	@Override
 	protected String operationGenerate(String javaStrings, String nameClass, String parameters) {
+		if (this.springVersion == '2.x') {
+			javaStrings.replace('.findOne(id)', '.findById(id).get()');
+		}
 		return javaStrings.replace("${package}", getPackage() + ".service")
 				.replace("${package_model}", getPackage() + ".model")
 				.replace("${package_repository}", getPackage() + ".repository")

--- a/spring-boot-generate/src/main/java/br/com/generate/setup/command/SetupGenerator.java
+++ b/spring-boot-generate/src/main/java/br/com/generate/setup/command/SetupGenerator.java
@@ -27,10 +27,12 @@ public class SetupGenerator extends ReadScaffoldInfo {
 			String dataBaseName = params[1] != null ? params[1] : "mydb";
 			String userDataBase = params[2] != null ? params[2] : "root";
 			String passWordDatabase = params[3] != null ? params[3] : "root";
+			String springVersion = params[4] != null ? params[4] : "2.x";
 			writer.println("package:" + namePackage);
 			writer.println("dataBaseName:" + dataBaseName);
 			writer.println("username:" + userDataBase);
 			writer.println("password:" + passWordDatabase);
+			writer.println("springVersion:" + springVersion);
 			writer.close();
 			System.out.println("create /src/main/resources/scaffold.info");
 		} catch (FileNotFoundException e) {

--- a/spring-boot-generate/src/main/java/br/com/generate/setup/command/SetupGenerator.java
+++ b/spring-boot-generate/src/main/java/br/com/generate/setup/command/SetupGenerator.java
@@ -27,7 +27,7 @@ public class SetupGenerator extends ReadScaffoldInfo {
 			String dataBaseName = params[1] != null ? params[1] : "mydb";
 			String userDataBase = params[2] != null ? params[2] : "root";
 			String passWordDatabase = params[3] != null ? params[3] : "root";
-			String springVersion = params[4] != null ? params[4] : "2.x";
+			String springVersion = params[4] != null ? params[4] : "1.x";
 			writer.println("package:" + namePackage);
 			writer.println("dataBaseName:" + dataBaseName);
 			writer.println("username:" + userDataBase);

--- a/spring-boot-generate/src/main/resources/scaffold.info
+++ b/spring-boot-generate/src/main/resources/scaffold.info
@@ -1,3 +1,4 @@
 package:br.com.example
 user-database:root
 password-database:root
+springVersion:2.x

--- a/spring-boot-generate/src/main/resources/scaffold.info
+++ b/spring-boot-generate/src/main/resources/scaffold.info
@@ -1,4 +1,4 @@
 package:br.com.example
 user-database:root
 password-database:root
-springVersion:2.x
+springVersion:1.x

--- a/spring-scaffold-cli/src/main/java/br/com/netodevel/command/setup/SetupScaffoldCommand.java
+++ b/spring-scaffold-cli/src/main/java/br/com/netodevel/command/setup/SetupScaffoldCommand.java
@@ -16,7 +16,7 @@ public class SetupScaffoldCommand extends OptionParsingCommand {
 
 	@Override
 	public String getUsageHelp() {
-		return "[namepackage][user-database][password-database]";
+		return "[namepackage][user-database][password-database][string-version]";
 	}
 	
 	@Override

--- a/spring-scaffold-cli/src/main/java/br/com/netodevel/command/setup/SetupScaffoldCommand.java
+++ b/spring-scaffold-cli/src/main/java/br/com/netodevel/command/setup/SetupScaffoldCommand.java
@@ -16,7 +16,7 @@ public class SetupScaffoldCommand extends OptionParsingCommand {
 
 	@Override
 	public String getUsageHelp() {
-		return "[namepackage][user-database][password-database][string-version]";
+		return "[namepackage][user-database][password-database][spring-version]";
 	}
 	
 	@Override

--- a/spring-scaffold-cli/src/main/java/br/com/netodevel/command/setup/SetupScaffoldHandler.java
+++ b/spring-scaffold-cli/src/main/java/br/com/netodevel/command/setup/SetupScaffoldHandler.java
@@ -28,6 +28,9 @@ public class SetupScaffoldHandler extends OptionHandler {
 	
 	@SuppressWarnings("unused")
 	private OptionSpec<String> passwordDatabase;
+
+	@SuppressWarnings("unused")
+	private OptionSpec<String> springVersion;
 	
 	@Override
 	protected void options() {
@@ -35,6 +38,7 @@ public class SetupScaffoldHandler extends OptionHandler {
 		this.dataBase = option(Arrays.asList("dataBaseName", "d"), "name of database").withOptionalArg();
 		this.userDatabase = option(Arrays.asList("userDatabase", "u"), "username database for migrates").withOptionalArg();
 		this.passwordDatabase = option(Arrays.asList("passwordDatabase", "p"), "password database for migrates").withOptionalArg();
+		this.springVersion = option(Arrays.asList("springVersion", "s"), "spring version: 1.x or 2.x").withOptionalArg();
 	}
 	
 	@Override
@@ -43,13 +47,15 @@ public class SetupScaffoldHandler extends OptionHandler {
 		String nameDataBase = (String) options.valueOf("d");
 		String userNameDatabase = (String) options.valueOf("u");
 		String passwordDatabase = (String) options.valueOf("p");
+		String springVersion = (String) options.valueOf("s");
 		
 		namePackage = namePackage != null ? namePackage.trim() : namePackage;
 		nameDataBase = nameDataBase != null ? nameDataBase.trim() : nameDataBase;
 		userNameDatabase = userNameDatabase != null ? userNameDatabase.trim() : userNameDatabase;
 		passwordDatabase = passwordDatabase != null ? passwordDatabase.trim() : passwordDatabase;
+		springVersion = springVersion != null ? springVersion.trim() : springVersion;
 		
-		new SetupGenerator(namePackage, nameDataBase, userNameDatabase, passwordDatabase);
+		new SetupGenerator(namePackage, nameDataBase, userNameDatabase, passwordDatabase, springVersion);
 		new ApplicationPropertiesGenerator();
 		
 		return ExitStatus.OK;

--- a/spring-scaffold-cli/src/main/resources/scaffold.info
+++ b/spring-scaffold-cli/src/main/resources/scaffold.info
@@ -1,3 +1,4 @@
 package:br.com.example
 user-database:root
 password-database:root
+springVersion:2.x

--- a/spring-scaffold-cli/src/main/resources/scaffold.info
+++ b/spring-scaffold-cli/src/main/resources/scaffold.info
@@ -1,4 +1,4 @@
 package:br.com.example
 user-database:root
 password-database:root
-springVersion:2.x
+springVersion:1.x


### PR DESCRIPTION
First, congratulations, the project is so great.

I read the discussion on https://github.com/NetoDevel/cli-spring-boot-scaffold/pull/44 about code generator in spring 2. Given your necessity to keep retro compatibility with spring 1, I did some work on it and tried to change the minimal. I hope you appreciate it.

 - The major difference between Spring 1 and 2 (in crud context) is the method findOne(), that expect an object in spring 2, while spring 1 expect an id (what break the app). So, a simple way to handle this: in the service, return findOne(id) to spring 1 and findById(id).get() to spring 2. 

- To achieve that, and as you suggested, now scaffold.info have a variable called springVersion that can be 1.x or 2.x, and the generator handle the correct method findOne or findById accordingly

- In version 2.x, I did not investigated yet,  but the bootstrap cdn is not being load. But I will leave this to another issue/PR

- I am sending a minimal .gitignore

- I dit not generate a new sample project, because we can discuss before how organize the samples. Something like: sample/1.x, sample/2.x. This can be another issue/PR

- I do not change the spring version of your project. It is still 1.4.2.RELEASE, but now it generates code to version 2.x of spring

- I do not change artifact version, it is still 0.0.1.BUILD-SNAPSHOT. 

- Default scaffold is to spring 1.x

That is it! The generator now works with spring 1 and spring 2 by change scaffold.info